### PR TITLE
日跨ぎ(繰り返し)イベントのカレンダー通知キー修正

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,6 +113,8 @@ dependencies {
 
     implementation(libs.mlkitFaceDetection)
 
+    testImplementation(libs.junit4)
+
     androidTestImplementation(platform(libs.androidxComposeBom))
     androidTestImplementation(libs.androidxJunit)
     androidTestImplementation(libs.androidxEspressoCore)

--- a/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/feature/alert/AlertManager.kt
+++ b/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/feature/alert/AlertManager.kt
@@ -139,10 +139,10 @@ class AlertManager(
     }
 
     private fun cleanupOldAlerts(currentEvents: List<CalendarRepository.CalendarEvent>) {
-        val currentEventIds = currentEvents.map { it.id }.toSet()
+        val currentEventIdentifiers = currentEvents.map { alertKey.eventIdentifier(it) }.toSet()
         val keysToRemove = activeAlerts.keys.filter { key ->
-            val eventId = alertKey.parseEventId(key)
-            eventId !in currentEventIds
+            val eventIdentifier = alertKey.parseEventIdentifier(key)
+            eventIdentifier !in currentEventIdentifiers
         }
 
         keysToRemove.forEach { key ->
@@ -151,8 +151,8 @@ class AlertManager(
         }
 
         val dismissedKeysToRemove = dismissedAlerts.filter { key ->
-            val eventId = alertKey.parseEventId(key)
-            eventId !in currentEventIds
+            val eventIdentifier = alertKey.parseEventIdentifier(key)
+            eventIdentifier !in currentEventIdentifiers
         }
 
         dismissedKeysToRemove.forEach { key ->
@@ -197,11 +197,18 @@ class AlertManager(
 
     class AlertKey {
         fun create(event: CalendarRepository.CalendarEvent, alertType: AlertType): String {
-            return "${event.id}_${alertType.name}"
+            return "${eventIdentifier(event)}|${alertType.name}"
         }
 
-        fun parseEventId(alertKey: String): Long? {
-            return alertKey.split("_")[0].toLongOrNull()
+        fun parseEventIdentifier(alertKey: String): String {
+            return alertKey.substringBefore("|")
+        }
+
+        internal fun eventIdentifier(event: CalendarRepository.CalendarEvent): String {
+            return when (event) {
+                is CalendarRepository.CalendarEvent.Time -> "${event.id}@${event.startTime.epochSecond}"
+                is CalendarRepository.CalendarEvent.AllDay -> "${event.id}@allDay"
+            }
         }
     }
 

--- a/app/src/test/kotlin/net/matsudamper/allintoolscreensaver/feature/alert/AlertManagerAlertKeyTest.kt
+++ b/app/src/test/kotlin/net/matsudamper/allintoolscreensaver/feature/alert/AlertManagerAlertKeyTest.kt
@@ -9,6 +9,10 @@ import org.junit.Test
 
 class AlertManagerAlertKeyTest {
 
+    /**
+     * 同一のイベントIDを持つ繰り返し予定でも、発生日時が異なれば
+     * 通知キーは別物として扱われることを確認する。
+     */
     @Test
     fun recurringEventWithSameEventIdHasDifferentAlertKeyPerOccurrence() {
         val alertKey = AlertManager.AlertKey()
@@ -27,6 +31,10 @@ class AlertManagerAlertKeyTest {
         assertNotEquals(firstKey, nextDayKey)
     }
 
+    /**
+     * 生成済みの通知キーから、発生単位で一意なイベント識別子を
+     * 正しく取り出せることを確認する。
+     */
     @Test
     fun parseEventIdentifierReturnsOccurrenceScopedIdentifier() {
         val alertKey = AlertManager.AlertKey()

--- a/app/src/test/kotlin/net/matsudamper/allintoolscreensaver/feature/alert/AlertManagerAlertKeyTest.kt
+++ b/app/src/test/kotlin/net/matsudamper/allintoolscreensaver/feature/alert/AlertManagerAlertKeyTest.kt
@@ -1,0 +1,55 @@
+package net.matsudamper.allintoolscreensaver.feature.alert
+
+import java.time.Instant
+import net.matsudamper.allintoolscreensaver.feature.calendar.AttendeeStatus
+import net.matsudamper.allintoolscreensaver.feature.calendar.CalendarRepository
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class AlertManagerAlertKeyTest {
+
+    @Test
+    fun recurringEventWithSameEventIdHasDifferentAlertKeyPerOccurrence() {
+        val alertKey = AlertManager.AlertKey()
+        val firstOccurrence = createTimeEvent(
+            id = 42,
+            startTime = Instant.parse("2026-01-01T23:59:00Z"),
+        )
+        val nextDayOccurrence = createTimeEvent(
+            id = 42,
+            startTime = Instant.parse("2026-01-02T23:59:00Z"),
+        )
+
+        val firstKey = alertKey.create(firstOccurrence, AlertManager.AlertType.EVENT_TIME)
+        val nextDayKey = alertKey.create(nextDayOccurrence, AlertManager.AlertType.EVENT_TIME)
+
+        assertNotEquals(firstKey, nextDayKey)
+    }
+
+    @Test
+    fun parseEventIdentifierReturnsOccurrenceScopedIdentifier() {
+        val alertKey = AlertManager.AlertKey()
+        val event = createTimeEvent(
+            id = 99,
+            startTime = Instant.parse("2026-02-01T00:00:00Z"),
+        )
+
+        val key = alertKey.create(event, AlertManager.AlertType.ONE_MINUTE_BEFORE)
+
+        assertEquals("99@1769904000", alertKey.parseEventIdentifier(key))
+    }
+
+    private fun createTimeEvent(id: Long, startTime: Instant): CalendarRepository.CalendarEvent.Time {
+        return CalendarRepository.CalendarEvent.Time(
+            id = id,
+            calendarId = 1,
+            title = "event",
+            description = null,
+            color = 0,
+            attendeeStatus = AttendeeStatus.ACCEPTED,
+            startTime = startTime,
+            endTime = startTime.plusSeconds(600),
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 
 [libraries]
 androidxCoreKtx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
+junit4 = { group = "junit", name = "junit", version.ref = "junit" }
 androidxDatastore = { module = "androidx.datastore:datastore", version.ref = "datastore" }
 androidxDocumentfile = { module = "androidx.documentfile:documentfile", version.ref = "documentfile" }
 coilCompose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }


### PR DESCRIPTION
### Motivation
- 同一の `event.id` を持つ繰り返しイベントが日付をまたぐと通知キーが重複し翌日の通知が抑止される問題を解消するため。 
- 再発防止のためイベント発生ごとに一意の識別子で管理し、古いアラートのクリーンアップも整合させる必要があった。 

### Description
- `AlertManager.AlertKey` のキー生成を `"${event.id}@<occurrence>|<alertType>"` 形式に変更して発生ごとに一意化したため、同一IDの別日発生を区別するようにした。 
- 古いアラート削除処理を `event.id` ベースから新しい発生単位の識別子（`eventIdentifier`）ベースに変更して整合性を保った。 
- `AlertManager.AlertKey` に `eventIdentifier` を公開（`internal`）し、`parseEventIdentifier` を追加してキー解析を行うようにした。 
- ユニットテスト `AlertManagerAlertKeyTest` を追加し、同一 `event.id` の別発生でキーが異なることと `parseEventIdentifier` の期待値を検証するようにした。 
- `app` モジュールにローカルユニットテスト用の `junit4` 依存を追加した。 

### Testing
- `./gradlew :app:testDebugUnitTest --tests "*AlertManagerAlertKeyTest"` を実行してユニットテストを実行し成功した（ビルドは `BUILD SUCCESSFUL`）。 
- 追加したテストは `AlertManagerAlertKeyTest` の2ケースが実行されており両方とも合格した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae5c2a79f483259ea9f44d107b34ed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Alerts for recurring events are now scoped per occurrence so dismissals and cleanup behave correctly.

* **Tests**
  * Added unit tests covering alert key/identifier behavior to improve reliability.

* **Chores**
  * Updated test dependency configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->