### PR TITLE
Update to Android 37 SDK and Material3 Adaptive 1.3.0-rc01

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,12 +8,12 @@ plugins {
 
 android {
     namespace = "net.matsudamper.allintoolscreensaver"
-    compileSdk = 36
+    compileSdkVersion("android-37.0")
 
     defaultConfig {
         applicationId = "net.matsudamper.allintoolscreensaver"
         minSdk = 35
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0"
 

--- a/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/MainActivity.kt
+++ b/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/MainActivity.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -66,7 +66,7 @@ class MainActivity : ComponentActivity() {
                     }
                 },
                 sceneStrategy = run {
-                    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+                    val windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass
                     remember(windowSizeClass) {
                         CustomTwoPaneSceneStrategy(
                             windowSizeClass = windowSizeClass,

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.2"
+agp = "9.1.0"
 coilCompose = "2.7.0"
 detektVersion = "0.5.6"
 documentfile = "1.1.0"
@@ -26,7 +26,7 @@ haze = "1.7.2"
 nav3Core = "1.0.1"
 lifecycleViewmodelNav3 = "2.10.0"
 kotlinxSerializationCore = "1.9.0"
-material3Adaptive = "1.3.0-SNAPSHOT"
+material3Adaptive = "1.3.0-rc01"
 mlkitFaceDetection = "16.1.7"
 
 [plugins]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven("https://androidx.dev/snapshots/latest/artifacts/repository")
     }
 }
 

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "net.matsudamper.allintoolscreensaver.ui"
-    compileSdk = 36
+    compileSdkVersion("android-37.0")
 
     defaultConfig {
         minSdk = 35


### PR DESCRIPTION
## 概要
Android SDK 37へのアップグレードと、Material3 Adaptiveライブラリの安定版リリース候補への更新を行いました。

## 主な変更点

- **Android SDK バージョン更新**
  - compileSdk を 36 から 37 に更新
  - targetSdk を 36 から 37 に更新
  - `compileSdk` から `compileSdkVersion()` APIへの移行

- **Material3 Adaptive ライブラリ更新**
  - バージョンを `1.3.0-SNAPSHOT` から `1.3.0-rc01` に更新
  - `currentWindowAdaptiveInfo()` から `currentWindowAdaptiveInfoV2()` へのAPI更新に対応

- **ビルドツール更新**
  - AGP (Android Gradle Plugin) を 8.13.2 から 9.1.0 に更新
  - gradle.properties に `android.builtInKotlin=false` と `android.newDsl=false` を追加

- **リポジトリ設定の簡素化**
  - androidx.dev スナップショットリポジトリを削除（Material3 Adaptiveが安定版RCになったため）

## 実装の詳細

Material3 Adaptiveの新しいAPIに対応するため、`MainActivity.kt`で`currentWindowAdaptiveInfoV2()`を使用するように更新しました。この変更により、ウィンドウサイズクラスの取得がより安定した方法で行われるようになります。

https://claude.ai/code/session_012qAsWAodvZbkBMH9jnr5uZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated to Android SDK 37 for improved compatibility and performance
  * Enhanced adaptive window support for better responsiveness across device configurations
  * Updated build toolchain and dependencies to latest stable versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->