### PR TITLE
カレンダーイベントのアラーム有無を追跡

### DIFF
--- a/app/src/androidTest/java/net/matsudamper/allintoolscreensaver/CalendarDisplayScreenTest.kt
+++ b/app/src/androidTest/java/net/matsudamper/allintoolscreensaver/CalendarDisplayScreenTest.kt
@@ -94,6 +94,7 @@ class CalendarDisplayScreenTest {
             startTime = startTime.atZone(ZoneId.systemDefault()).toInstant(),
             endTime = endTime.atZone(ZoneId.systemDefault()).toInstant(),
             attendeeStatus = AttendeeStatus.ACCEPTED,
+            hasAlarm = true,
         )
 
         val event2 = CalendarRepository.CalendarEvent.Time(
@@ -105,6 +106,7 @@ class CalendarDisplayScreenTest {
             startTime = startTime.plusMinutes(30).atZone(ZoneId.systemDefault()).toInstant(),
             endTime = endTime.plusMinutes(30).atZone(ZoneId.systemDefault()).toInstant(),
             attendeeStatus = AttendeeStatus.ACCEPTED,
+            hasAlarm = true,
         )
 
         calendarRepository.addEvent(event1)

--- a/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/feature/alert/AlertManager.kt
+++ b/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/feature/alert/AlertManager.kt
@@ -84,6 +84,7 @@ class AlertManager(
 
     private fun checkAlertForEvent(event: CalendarRepository.CalendarEvent.Time, now: Instant) {
         if (event.attendeeStatus == AttendeeStatus.DECLINED) return
+        if (!event.hasAlarm) return
 
         val eventStartTime = event.startTime
 

--- a/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/feature/alert/AlertManager.kt
+++ b/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/feature/alert/AlertManager.kt
@@ -79,7 +79,7 @@ class AlertManager(
             checkAlertForEvent(event, now)
         }
 
-        cleanupOldAlerts(events)
+        cleanupOldAlerts(events.filter { it.hasAlarm })
     }
 
     private fun checkAlertForEvent(event: CalendarRepository.CalendarEvent.Time, now: Instant) {

--- a/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/feature/calendar/CalendarRepositoryImpl.kt
+++ b/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/feature/calendar/CalendarRepositoryImpl.kt
@@ -37,6 +37,7 @@ interface CalendarRepository {
         val description: String?
         val color: Int
         val attendeeStatus: AttendeeStatus
+        val hasAlarm: Boolean
 
         data class Time(
             override val id: Long,
@@ -45,6 +46,7 @@ interface CalendarRepository {
             override val description: String?,
             override val color: Int,
             override val attendeeStatus: AttendeeStatus,
+            override val hasAlarm: Boolean,
             val startTime: Instant,
             val endTime: Instant,
         ) : CalendarEvent
@@ -56,6 +58,7 @@ interface CalendarRepository {
             override val description: String?,
             override val color: Int,
             override val attendeeStatus: AttendeeStatus,
+            override val hasAlarm: Boolean,
         ) : CalendarEvent
     }
 }
@@ -124,6 +127,7 @@ class CalendarRepositoryImpl(private val context: Context) : CalendarRepository 
                 CalendarContract.Instances.CALENDAR_COLOR,
                 CalendarContract.Instances.EVENT_COLOR,
                 CalendarContract.Instances.SELF_ATTENDEE_STATUS,
+                CalendarContract.Instances.HAS_ALARM,
             )
 
             // その日付のUTCでの始まりの時間を取得
@@ -188,6 +192,10 @@ class CalendarRepositoryImpl(private val context: Context) : CalendarRepository 
                         }
                     }
                 }
+                val hasAlarm = run {
+                    val hasAlarmIndex = c.getColumnIndexOrThrow(CalendarContract.Instances.HAS_ALARM)
+                    !c.isNull(hasAlarmIndex) && c.getInt(hasAlarmIndex) == 1
+                }
                 events.add(
                     if (allDay) {
                         CalendarRepository.CalendarEvent.AllDay(
@@ -197,6 +205,7 @@ class CalendarRepositoryImpl(private val context: Context) : CalendarRepository 
                             description = description,
                             color = color,
                             attendeeStatus = attendeeStatus,
+                            hasAlarm = hasAlarm,
                         )
                     } else {
                         val startTime = Instant.ofEpochMilli(eventStartTime)
@@ -237,6 +246,7 @@ class CalendarRepositoryImpl(private val context: Context) : CalendarRepository 
                             endTime = endTime,
                             color = color,
                             attendeeStatus = attendeeStatus,
+                            hasAlarm = hasAlarm,
                         )
                     },
                 )

--- a/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/viewmodel/CalendarDisplayScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/viewmodel/CalendarDisplayScreenViewModel.kt
@@ -108,6 +108,7 @@ class CalendarDisplayScreenViewModel(
                                         alertType = run alertType@{
                                             val isAlertCalendar = event.calendarId in viewModelState.alertCalendarIds
                                             if (!isAlertCalendar) return@alertType CalendarLayoutUiState.Event.AlertType.NONE
+                                            if (!event.hasAlarm) return@alertType CalendarLayoutUiState.Event.AlertType.NONE
                                             if (viewModelState.alertEnabled) {
                                                 CalendarLayoutUiState.Event.AlertType.ALERT
                                             } else {

--- a/app/src/test/kotlin/net/matsudamper/allintoolscreensaver/feature/alert/AlertManagerAlertKeyTest.kt
+++ b/app/src/test/kotlin/net/matsudamper/allintoolscreensaver/feature/alert/AlertManagerAlertKeyTest.kt
@@ -56,6 +56,7 @@ class AlertManagerAlertKeyTest {
             description = null,
             color = 0,
             attendeeStatus = AttendeeStatus.ACCEPTED,
+            hasAlarm = true,
             startTime = startTime,
             endTime = startTime.plusSeconds(600),
         )


### PR DESCRIPTION
## 概要
カレンダーイベントがアラーム設定を持っているかどうかを追跡する機能を追加しました。

## 主な変更
- `CalendarRepository.CalendarEvent`インターフェースに`hasAlarm`プロパティを追加
- `CalendarEvent.Time`と`CalendarEvent.AllDay`の両実装に`hasAlarm`フィールドを追加
- `CalendarRepositoryImpl`でAndroid CalendarProviderから`HAS_ALARM`カラムを取得し、イベント作成時に設定
- `AlertManager.checkAlertForEvent()`でアラーム設定がないイベントをスキップするようにフィルタリング
- テストコードを更新して新しい`hasAlarm`パラメータを設定

## 実装の詳細
- `CalendarContract.Instances.HAS_ALARM`カラムを取得し、nullチェックと値が1であることを確認してboolean値に変換
- アラーム機能は、ユーザーが明示的にアラームを設定したイベントのみを対象とするため、この情報を活用してアラート処理を最適化

https://claude.ai/code/session_01KvCNJrvz2chwb3HhHvLFov

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar events without alarms no longer trigger alerts or influence alert state cleanup.
  * Alert behavior is now based on the actual alarm flag for both timed and all-day events.
  * The calendar display will show no alert type for events that have alarms disabled.
* **Tests**
  * Updated calendar overlap and alert-related tests to explicitly create events with alarms enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->