### PR TITLE
detektのCompilerWarning指摘を解消

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/feature/FaceDetectionManager.kt
+++ b/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/feature/FaceDetectionManager.kt
@@ -6,7 +6,6 @@ import android.graphics.ImageDecoder
 import android.net.Uri
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.BiasAlignment
-import kotlin.coroutines.resume
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
@@ -67,10 +66,10 @@ class FaceDetectionManager(private val context: Context) {
                             centerY = face.boundingBox.exactCenterY(),
                         )
                     }
-                    continuation.resume(centers)
+                    continuation.resumeWith(Result.success(centers))
                 }
                 .addOnFailureListener {
-                    continuation.resume(null)
+                    continuation.resumeWith(Result.success(null))
                 }
         }
     }

--- a/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/feature/alert/AlertManager.kt
+++ b/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/feature/alert/AlertManager.kt
@@ -93,13 +93,12 @@ class AlertManager(
             val alertKeyValue = alertKey.create(event, alertType)
 
             if (shouldTriggerAlert(alertKeyValue, alertTime, now)) {
-                val alertInfo = AlertInfo(
+                activeAlerts[alertKeyValue] = AlertInfo(
                     event = event,
                     alertType = alertType,
                     triggeredAt = now,
                     isRepeating = alertType == AlertType.EVENT_TIME,
                 )
-                activeAlerts[alertKeyValue] = alertInfo
 
                 if (alertType == AlertType.EVENT_TIME) {
                     repeatingAlerts[alertKeyValue] = now

--- a/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/viewmodel/MainScreenViewModelListenerImpl.kt
+++ b/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/viewmodel/MainScreenViewModelListenerImpl.kt
@@ -15,7 +15,6 @@ import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
-import kotlin.coroutines.resume
 import kotlinx.coroutines.suspendCancellableCoroutine
 import net.matsudamper.allintoolscreensaver.ActivityResultRequest
 import net.matsudamper.allintoolscreensaver.feature.calendar.CalendarRepository
@@ -143,7 +142,7 @@ class MainScreenViewModelListenerImpl(
                     contract = contract,
                     input = input,
                     result = { output ->
-                        continuation.resume(output)
+                        continuation.resumeWith(Result.success(output))
                     },
                 ) as ActivityResultRequest<Any, Any>,
             )

--- a/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/viewmodel/SlideshowScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/allintoolscreensaver/viewmodel/SlideshowScreenViewModel.kt
@@ -183,9 +183,13 @@ class SlideshowScreenViewModel(
             return
         }
 
-        val directoryUri =
-            settingsRepositor.settingsFlow.first().imageDirectoryUri.takeIf { it.isNotEmpty() }
-                ?.toUri() ?: return updateLoadingFalse()
+        val directoryUri = settingsRepositor.settingsFlow.first().imageDirectoryUri
+            .takeIf { it.isNotEmpty() }
+            ?.toUri()
+        if (directoryUri == null) {
+            updateLoadingFalse()
+            return
+        }
 
         if (viewModelStateFlow.value.images.isEmpty()) {
             val uris = imageManager.getImageUrisFromDirectory(directoryUri)


### PR DESCRIPTION
## 背景

Renovateの依存更新PR (#122 など) で `./gradlew detektDebug` が `Analysis failed with 9 weighted issues` で失敗していた。

指摘内容は以下の9件で、#122 の差分 (`gradle-wrapper.properties` の1行のみ) とは無関係。`renovate/koin` のCIログでもまったく同じ9件が出ている。

| ファイル | 指摘 |
|---|---|
| SlideshowScreenViewModel.kt:186,190 | UNUSED_VARIABLE / UNREACHABLE_CODE ×2 / UnreachableCode ×2 |
| AlertManager.kt:95 | UNUSED_VARIABLE |
| FaceDetectionManager.kt:70,73 | DEPRECATION ×2 |
| MainScreenViewModelListenerImpl.kt:146 | DEPRECATION |

指摘の出所は `com.braisgabin.detekt:kotlin-compiler-wrapper` の `CompilerWarning` ルールで、detekt 1.23.8 が内蔵する古い(K1系)フロントエンドの解析結果。実際の Kotlin 2.2.21 でのコンパイルは警告ゼロなのでK1側の偽陽性を含むが、指摘対象のコードはmasterにそのまま存在していた。

masterのCIでは表面化していなかっただけで、ローカルでは以下のとおり再現した。

- masterのまま Gradle 9.6.1 → `detektDebug` 成功
- masterのまま Gradle 9.7.0 に差し替え → 同じ9件で失敗

## 変更内容

suppress / ignore の追加はせず、コード側で解消した。

1. `SlideshowScreenViewModel.updateImages`: `?: return updateLoadingFalse()` を null チェックの `if` に変更 (5件解消)
2. `AlertManager.checkAlertForEvent`: ローカル変数 `alertInfo` を廃止して直接代入 (1件解消)
3. `FaceDetectionManager` / `MainScreenViewModelListenerImpl`: `CancellableContinuation.resume(x)` を `resumeWith(Result.success(x))` に変更し、未使用になった `import kotlin.coroutines.resume` を削除 (3件解消)

## 動作確認

1つずつ実行し、すべて成功。

- `./gradlew assembleDebug`
- `./gradlew assembleDebugAndroidTest`
- `./gradlew detekt detektMain`
- `./gradlew :app:lintDebug`
- `./gradlew ktlintFormat`
- Gradle 9.7.0 に差し替えた状態の `./gradlew :app:detektDebug` が0件で成功することも確認

UIテスト (`pixel9api35DebugAndroidTest`) はエミュレータが用意できない環境のため未実行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N995p7M28C1dHjUajoakJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01N995p7M28C1dHjUajoakJ5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slideshow behavior when no image folder is configured by correctly clearing the loading state.
  * Improved reliability of face detection and permission handling during asynchronous operations.

* **Refactor**
  * Simplified internal alert processing without changing alert behavior or displayed information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->