### PR TITLE
GitHub ActionsのJDKを最新LTS(25)に更新

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,9 @@ jobs:
     - name: Set up JDK 25
       uses: actions/setup-java@v5
       with:
-        java-version: '25'
+        java-version: |
+          21
+          25
         distribution: 'temurin'
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v5
@@ -33,6 +35,8 @@ jobs:
         path: app/build/outputs/apk/debug/*.apk
     - name: Detekt
       run: ./gradlew detektDebug
+      env:
+        JAVA_HOME: ${{ env.JAVA_HOME_21_X64 }}
     - name: Android Lint
       run: ./gradlew lint
     - name: Upload lint reports

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,10 +14,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v7
 
-    - name: Set up JDK 17
+    - name: Set up JDK 25
       uses: actions/setup-java@v5
       with:
-        java-version: '17'
+        java-version: '25'
         distribution: 'temurin'
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v5
@@ -51,10 +51,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v7
 
-    - name: Set up JDK 17
+    - name: Set up JDK 25
       uses: actions/setup-java@v5
       with:
-        java-version: '17'
+        java-version: '25'
         distribution: 'temurin'
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v5

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,9 @@ allprojects {
             "$rootDir/.detekt/custom.yml",
         )
     }
+    tasks.withType<io.gitlab.arturbosch.detekt.Detekt> {
+        jvmTarget = "17"
+    }
     dependencies {
         detektPlugins(rootProject.libs.kotlinCompilerWrapper)
         detektPlugins(rootProject.libs.detekt)

--- a/costom-detekt-rules/build.gradle.kts
+++ b/costom-detekt-rules/build.gradle.kts
@@ -3,6 +3,15 @@ plugins {
     alias(libs.plugins.detekt)
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+}
+
 dependencies {
     compileOnly("io.gitlab.arturbosch.detekt:detekt-api:1.23.8")
     compileOnly("io.gitlab.arturbosch.detekt:detekt-psi-utils:1.23.8")

--- a/ktlint-custom-rules/build.gradle.kts
+++ b/ktlint-custom-rules/build.gradle.kts
@@ -3,6 +3,15 @@ plugins {
     alias(libs.plugins.ktlintGradle)
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+}
+
 dependencies {
     implementation(libs.ktlintRuleEngine)
     implementation(libs.ktlintCliRulesetCore)


### PR DESCRIPTION
## Summary

`.github/workflows/check.yml` のJDKを `17` から最新LTSの `25` に更新した。ただしdetektがJDK 25で動作しないため、**Detektステップのみ JDK 21 で実行**している。

### なぜJDK 21も入っているのか

detektは `processIsolation` でワーカープロセスをforkし、そのJVMはGradleデーモンと同じJDKになる。detekt 1.23.8（最新リリース。2.xは未リリース）はJDK 25ランタイム上でクラッシュするため、コンパイルターゲットを17に固定しても、detektを**実行する**JVMがJDK 25である限り失敗する（実際にrun #1083で失敗を確認）。

そのため `setup-java` で21と25の両方をインストールし、

- `JAVA_HOME` は最後に記述した25 → ワークフローの既定Javaは最新LTSの25
- Detektステップだけ `JAVA_HOME_21_X64` で21に切り替え

という構成にしている。ktlint / assembleDebug / lint / instrumented tests は全てJDK 25で実行される。

### 変更内容

| ファイル | 変更 |
| --- | --- |
| `.github/workflows/check.yml` | JDKを25に更新。`test` ジョブは21と25の両方をインストールし、DetektステップのみJDK 21で実行 |
| `build.gradle.kts` | DetektタスクのjvmTargetを17に固定 |
| `ktlint-custom-rules/build.gradle.kts` | Java/KotlinのターゲットをJava 17に明示 |
| `costom-detekt-rules/build.gradle.kts` | Java/KotlinのターゲットをJava 17に明示 |

jvmTargetの固定が必要なのは、Kotlin 2.2.21がJVM target 25に未対応のため。JDK 25上ではJavaのコンパイルが25を、Kotlinが24をターゲットにしてしまい、ターゲット不一致でビルドが失敗する。

## Test plan

- [x] CI (Check ワークフロー) が正常に完走することを確認（run #1084 / `test`・`android-test` 両ジョブ成功）
- [x] DetektステップがJDK 21で実行されていることをCIログで確認（Detektステップの `JAVA_HOME` が `.../jdk/21.0.11-10/x64`、直後のAndroid Lintステップは `.../jdk/25.0.3-9/x64`）

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD3rHp8taMuu7M7R2iFwH)_


## Summary by CodeRabbit

* **Chores**
  * Updated automated testing workflows to run with Java 25.
  * Continued using the Temurin Java distribution for test environments.
  * Improved build and code-quality tooling compatibility across supported Java versions.
  * Standardized JVM targets for static analysis and custom rule modules to provide more consistent validation results.
